### PR TITLE
Remove `pull_policy` from docker-compose.yml file.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,7 +64,6 @@ services:
 
   terrad:
     image: terramoney/localterra-core:bombay
-    pull_policy: always
     volumes:
       - ./LocalTerra/config:/root/.terra/config
     networks:
@@ -77,7 +76,6 @@ services:
     command: terrad start
   fcd-collector:
     image: terramoney/fcd:1.0.0-beta.2
-    pull_policy: always
     depends_on:
       - terrad
       - postgres
@@ -90,7 +88,6 @@ services:
 
   oracle:
     image: terramoney/pseudo-feeder:bombay
-    pull_policy: always
     depends_on:
       - terrad
     networks:
@@ -101,7 +98,6 @@ services:
 
   fcd-api:
     image: terramoney/fcd:1.0.0-beta.2
-    pull_policy: always
     depends_on:
       - terrad
       - postgres


### PR DESCRIPTION
Fixes #15 

This might be required by Swarm. If the demo is intended to run using Swarm, please update the instructions.